### PR TITLE
Alternate writing for a return value

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,80 +1,101 @@
 # TickerScheduler
 Simple scheduler for ESP8266 Arduino based on Ticker
 
-###Initialization###
+### Initialization
 
-```TickerScheduler(uint size); ```
+```
+TickerScheduler(uint size);
+```
 
-| Param | Description | 
+| Param | Description |
 | --- | --- |
 |  size  |  Amount of task Tickers to initialize  |
 
-**Example**: 
+**Example**:
 
-```TickerScheduler ts(5)```
+```
+TickerScheduler ts(5)
+```
 
 
-###Add task###
+### Add task
 
-```    boolean add(uint i, uint32_t period, tscallback_t f, boolean shouldFireNow = false); ```
+```
+    boolean add(uint i, uint32_t period, tscallback_t f, boolean shouldFireNow = false);
+```
 
-| Param | Description | 
+| Param | Description |
 | --- | --- |
 |  i  |  Task ID  |
 | period  | Task execution period in ms  |
 | f | Task callback |
-| shouldFireNow|  ```true``` if you want to execute task right after first scheduler update or wait next scheduled start |
+| shouldFireNow|  `true` if you want to execute task right after first scheduler update or wait next scheduled start |
 
 **Returns**:
 
-```true``` - task added sucessfully
+`true` - task added sucessfully
 
-```false``` - task was not added 
+`false` - task was not added
 
 **Example**:
 
-```ts.add(0, 3000, sendData)```
+```
+ts.add(0, 3000, sendData)
+```
 
-###Execute scheduler in ```loop()```###
+### Execute scheduler in `loop()`
 
-``` ts.update() ```
+```
+ ts.update()
+```
 
-###Remove task###
+### Remove task
 
-```boolean remove(uint i)```
-
-**Returns**:
-
-```true``` - task removed sucessfully
-
-```false``` - task was not removed
-
-| Param | Description | 
-| --- | --- |
-|  i  |  Task ID  |
-
-###Enable/Disable task###
-
-```boolean enable(uint i)```
-
-```boolean disable(uint i)```
+```
+boolean remove(uint i)
+```
 
 **Returns**:
 
-```true``` - task enabled/disabled sucessfully
+`true` - task removed sucessfully
 
-```false``` - task was not enabled/disabled
+`false` - task was not removed
 
-| Param | Description | 
+| Param | Description |
 | --- | --- |
 |  i  |  Task ID  |
 
-###Enable / disable all tasks###
+### Enable/Disable task
 
-``` void enableAll() ```
+```
+boolean enable(uint i)
+```
 
-``` void disableAll() ```
+```
+boolean disable(uint i)
+```
 
-###TODO###
+**Returns**:
+
+`true` - task enabled/disabled sucessfully
+
+`false` - task was not enabled/disabled
+
+| Param | Description |
+| --- | --- |
+|  i  |  Task ID  |
+
+### Enable / disable all tasks
+
+```
+ void enableAll()
+```
+
+```
+ void disableAll()
+```
+
+### TODO
+
 * Task callback parameters support
 * ...

--- a/TickerScheduler.cpp
+++ b/TickerScheduler.cpp
@@ -48,9 +48,7 @@ bool TickerScheduler::add(uint i, uint32_t period, tscallback_t f, boolean shoul
     this->items[i].period = period;
     this->items[i].is_used = true;
 
-    enable(i);
-
-    return true;
+    return enable(i);
 }
 
 bool TickerScheduler::remove(uint i)


### PR DESCRIPTION
Hi,

While reading your library, I found that the `add()` method returns `true` whatever the return value of `enable()` is. I thought one might want to change this, in case the code of `enable()` evolves in the future.

Besides, I took the freedom to alter a bit the formatting of the README file since it was not correctly parsed by my editor. I can remove these changes if you wish.

Do you think that the change to the `add()` method makes sense ? I'm actually not sure :)
