### PR TITLE
Fix for detaching a Ticker on AVR

### DIFF
--- a/TickerScheduler.cpp
+++ b/TickerScheduler.cpp
@@ -68,6 +68,11 @@ bool TickerScheduler::add(uint8_t i, uint32_t period, tscallback_t f, void* arg,
     return true;
 }
 
+bool TickerScheduler::once(uint8_t i, uint32_t period, tscallback_t f, void* arg)
+{
+    return add(i, period, f, arg, false);
+}
+
 bool TickerScheduler::remove(uint8_t i)
 {
     if (i >= this->size || !this->items[i].is_used)
@@ -128,7 +133,6 @@ void TickerScheduler::update()
 			this->items[i].t.Tick();
 			#endif
 
-            // handleTicker(this->items[i].cb, this->items[i].cb_arg, &this->items[i].flag);
 			handleTicker(&this->items[i]);
 		}
         yield();

--- a/TickerScheduler.h
+++ b/TickerScheduler.h
@@ -38,6 +38,14 @@ public:
 		this->callback_argument = arg;
 		this->is_attached = true;
 	}
+
+	template<typename TArg> void once_ms(uint32_t milliseconds, void(*callback)(TArg), TArg arg)
+	{
+		this->period = milliseconds;
+		this->callback = callback;
+		this->callback_argument = arg;
+		this->is_attached = true;
+	}
 };
 #endif
 
@@ -80,6 +88,7 @@ public:
     ~TickerScheduler();
     
     bool add(uint8_t i, uint32_t period, tscallback_t, void *, boolean repeat = true);
+    bool once(uint8_t i, uint32_t period, tscallback_t, void *);
     bool remove(uint8_t i);
     bool enable(uint8_t i);
     bool disable(uint8_t i);

--- a/TickerScheduler.h
+++ b/TickerScheduler.h
@@ -62,6 +62,7 @@ struct TickerSchedulerItem
 	void * cb_arg;
     uint32_t period;
     volatile bool is_used = false;
+    volatile bool repeat = true;
 };
 
 class TickerScheduler
@@ -71,13 +72,14 @@ private:
     TickerSchedulerItem *items = NULL;
 
     void handleTicker(tscallback_t, void *, volatile bool * flag);
+    void handleTicker(TickerSchedulerItem * item);
 	static void handleTickerFlag(volatile bool * flag);
 
 public:
     TickerScheduler(uint8_t size);
     ~TickerScheduler();
     
-    bool add(uint8_t i, uint32_t period, tscallback_t, void *, boolean shouldFireNow = false);
+    bool add(uint8_t i, uint32_t period, tscallback_t, void *, boolean repeat = true);
     bool remove(uint8_t i);
     bool enable(uint8_t i);
     bool disable(uint8_t i);

--- a/TickerScheduler.h
+++ b/TickerScheduler.h
@@ -28,7 +28,7 @@ public:
 
 	void detach()
 	{
-		this->is_attached = true;
+		this->is_attached = false;
 	}
 
 	template<typename TArg> void attach_ms(uint32_t milliseconds, void(*callback)(TArg), TArg arg)


### PR DESCRIPTION
On AVR it would not set is_attached to false, potentially enabling it on disable call.