### PR TITLE
ARDUINO_ARCH_AVR: detach

### DIFF
--- a/TickerScheduler.h
+++ b/TickerScheduler.h
@@ -30,7 +30,7 @@ public:
 
 	void detach()
 	{
-		this->is_attached = true;
+		this->is_attached = false;
 	}
 
 	template<typename TArg> void attach_ms(uint32_t milliseconds, void(*callback)(TArg), TArg arg)


### PR DESCRIPTION
For the case ARDUINO_ARCH_AVR, shouldn't Ticker::detach() should set is_attached to false?