### PR TITLE
Create library.json for registration with platformIOs library manager

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,21 @@
+{
+  "name": "TickerScheduler",
+  "version": "1.0.0",
+  "description": "Simple scheduler for ESP8266 & ESP32 Arduino based on Ticker",
+  "keywords": "Scheduler Ticker Timing",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/Toshik/TickerScheduler"
+  },
+  "authors":
+  [
+    {
+      "name": "Toshik",
+      "url": "https://github.com/Toshik"
+    }
+  ],
+  "homepage": "https://github.com/Toshik/TickerScheduler",
+  "frameworks": ["arduino"],
+  "platforms": ["espressif32", "espressif8266"]
+}


### PR DESCRIPTION
Hi there. I'm looking to use this library in a project, and always prefer using the PIO library manager for external dependencies. For that to work the libraries do however have to be registered, which requires some library manifest.

If you do add a license as noted in https://github.com/Toshik/TickerScheduler/issues/24, you can add a field to this json `"license":"MIT", ` for example, to have it properly reflected in PIO.

If you merge this could you also publish the package to PIO? https://docs.platformio.org/en/v5.1.0/core/userguide/package/cmd_publish.html#cmd-package-publish
If you'd rather not deal with that, I can add myself as maintainer to the manifest, and do the publishing, I just think you library should be associated with your account :) 